### PR TITLE
Get rid of check-types script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "lint": "turbo run lint",
     "format": "turbo run format",
     "test": "turbo run test",
-    "check-types": "turbo run check-types",
     "update-dependencies": "turbo run update-dependencies && npm run update-root-dependencies",
     "update-root-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",
     "generate": "turbo run generate",

--- a/turbo.json
+++ b/turbo.json
@@ -23,9 +23,6 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
-    "check-types": {
-      "dependsOn": ["^check-types"]
-    },
     "test": {
       "dependsOn": ["^test"]
     },


### PR DESCRIPTION
This check is included in the lint script already (when we first run tsc --noEmit).