### PR TITLE
Swap order of generate and build steps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,14 @@ jobs:
         echo DATABASE_URL="${{ secrets.DATABASE_URL }}" >> packages/prisma-client/.env.test
     - name: Install dependencies
       run: npm ci
-    - name: Build packages
-      run: npm run build --if-present
     - name: Generate Prisma Client
+      # The local utility package needs to be built so that we can disable tsc in the generated output
       run: |
         npm run migrate-deploy
+        npm run build -- --filter=@neurosongs/utility
         npm run generate-from-back-end
+    - name: Build packages
+      run: npm run build --if-present
     - name: Run linting checks
       run: npm run lint
     - name: Run tests


### PR DESCRIPTION
Generate should happen first so that the built packages and apps can reference the generated Prisma client.