### PR TITLE
Disallow importing .ts extensions

### DIFF
--- a/apps/front-end/src/main.tsx
+++ b/apps/front-end/src/main.tsx
@@ -4,7 +4,7 @@ import "src/index.css";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
-import App from "src/App.tsx";
+import App from "src/App";
 
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter>

--- a/apps/front-end/tsconfig.json
+++ b/apps/front-end/tsconfig.json
@@ -9,7 +9,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "allowImportingTsExtensions": false,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
Not needed for import paths in TypeScript.