### PR TITLE
Enforce type annotations on parser functions in types package

### DIFF
--- a/packages/types/eslint.config.js
+++ b/packages/types/eslint.config.js
@@ -1,3 +1,12 @@
 import plugin from "@alextheman/eslint-plugin";
 
-export default plugin.configs.alexTypeScriptBase;
+export default [
+  ...plugin.configs.alexTypeScriptBase,
+  {
+    rules: {
+      // This package literally exists to export types. Would be kinda silly not to give strict type annotations to parser functions
+      // who are meant to enforce strict types now, wouldn't it be?
+      "@typescript-eslint/explicit-module-boundary-types": "error",
+    },
+  },
+];


### PR DESCRIPTION
Since that package is a package dedicated entirely to providing types, maybe the functions should also be clear about the exact types being exported too. Just a thought, you know...