### PR TITLE
Provide a TransactionClient from types package

### DIFF
--- a/packages/types/src/PrismaClient.ts
+++ b/packages/types/src/PrismaClient.ts
@@ -1,5 +1,7 @@
 import type { PrismaClient as NeurosongsPrismaClient } from "@neurosongs/prisma-client/prisma";
 
-export type PrismaClient =
-  | NeurosongsPrismaClient
-  | Omit<NeurosongsPrismaClient, "$connect" | "$disconnect" | "$on" | "$transaction" | "$extends">;
+export type TransactionClient = Omit<
+  NeurosongsPrismaClient,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$extends"
+>;
+export type PrismaClient = NeurosongsPrismaClient | TransactionClient;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,4 +2,4 @@ export * from "src/albums";
 export * from "src/songs";
 export * from "src/users";
 
-export type { PrismaClient } from "src/PrismaClient";
+export type { PrismaClient, TransactionClient } from "src/PrismaClient";


### PR DESCRIPTION
This allows us to potentially have model files that only take a transaction client, which could be useful in cases where we have multiple database writes in a single model function, for whatever reason. Potentially cursed, but there could maybe be a use case for that.