### PR TITLE
Separate out router components into their own files

### DIFF
--- a/apps/front-end/src/Router.tsx
+++ b/apps/front-end/src/Router.tsx
@@ -2,22 +2,16 @@ import { Route, Routes } from "react-router-dom";
 
 import Homepage from "src/pages/Homepage";
 import Recent from "src/pages/Recent";
-import Album from "src/resources/Albums/pages/Album";
-import CreateAlbum from "src/resources/Albums/pages/mutations/CreateAlbum";
-import User from "src/resources/Users/pages/User";
+import AlbumsRouter from "src/resources/Albums/AlbumsRouter";
+import UsersRouter from "src/resources/Users/UsersRouter";
 
 function Router() {
   return (
     <Routes>
       <Route path="/" element={<Homepage />} />
       <Route path="/recent" element={<Recent />} />
-      <Route path="/users">
-        <Route path=":userId" element={<User />} />
-      </Route>
-      <Route path="/albums">
-        <Route path="create" element={<CreateAlbum />} />
-        <Route path=":albumId" element={<Album />} />
-      </Route>
+      {UsersRouter()}
+      {AlbumsRouter()}
     </Routes>
   );
 }

--- a/apps/front-end/src/resources/Albums/AlbumsRouter.tsx
+++ b/apps/front-end/src/resources/Albums/AlbumsRouter.tsx
@@ -1,0 +1,15 @@
+import { Route } from "react-router-dom";
+
+import Album from "src/resources/Albums/pages/Album";
+import CreateAlbum from "src/resources/Albums/pages/mutations/CreateAlbum";
+
+function AlbumsRouter() {
+  return (
+    <Route path="/albums">
+      <Route path="create" element={<CreateAlbum />} />
+      <Route path=":albumId" element={<Album />} />
+    </Route>
+  );
+}
+
+export default AlbumsRouter;

--- a/apps/front-end/src/resources/Users/UsersRouter.tsx
+++ b/apps/front-end/src/resources/Users/UsersRouter.tsx
@@ -1,0 +1,13 @@
+import { Route } from "react-router-dom";
+
+import User from "src/resources/Users/pages/User";
+
+function UsersRouter() {
+  return (
+    <Route path="/users">
+      <Route path=":userId" element={<User />} />
+    </Route>
+  );
+}
+
+export default UsersRouter;


### PR DESCRIPTION
This makes the base router feel tidier, since each resource controls its own router and then the main one can just import it and use that.

Note, however, that for some reason, doing something like <UsersRouter /> to pass the routes does not fully work. I think this is because <UsersRouter /> is interpreted as a component in itself rather than purely as a wrapper around the Route component. The Routes needs to see the Route component directly in order to work, and this is only possible when we actually call UsersRouter() as a raw function rather than a JSX element.