### PR TITLE
Add a step to ensure lockfile changes get committed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,12 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
+if git diff --name-only | grep package-lock.json; then
+  echo "❌ ERROR: Unstaged package-lock.json changes found. Please add the lockfile."
+  exit 1
+fi
+
+npm run build -- --ui=stream
 npm run format -- -- --ui=stream
 npm run lint -- -- --ui=stream
 npm test -- --ui=stream


### PR DESCRIPTION
This prevents a rogue package-lock.json change from not making it into a pull request. It can be very easy to forget this in a Turborepo where you can have your terminal set to different parts of the repository to run specific commands/scripts in just the isolated parts, but then you have to remember that the package-lock.json file is at the root and is not managed per workspace.